### PR TITLE
Use temp dir to check ffmpeg

### DIFF
--- a/src/gui/GeneralSettingDialog.cpp
+++ b/src/gui/GeneralSettingDialog.cpp
@@ -739,12 +739,16 @@ bool GeneralSettingDialog::ffmpegCheck(const QString& ffmpeg, GeneralSettingDial
     // Test FFmpeg functionality
     QMessageBox ffmpegNotif;
     ffmpegNotif.setIcon(QMessageBox::Critical);
+
+    QTemporaryDir tempDir;
+    QDir ffmpegOutputDir = tempDir.isValid() ? tempDir.path() : QDir::temp();
+
     // PNG to GIF conversion test
     QString testFile = QFileInfo("./data/themes/classic/icon/filew.png").absoluteFilePath();
     QProcess gif;
-    QString gifLoc = QFileInfo(ffmpeg).dir().absolutePath() + QString("/gif.gif");
+    QString gifLoc = ffmpegOutputDir.absoluteFilePath("gif.gif");
     qDebug() << gifLoc;
-    gif.start(ffmpeg, {"-i", testFile,gifLoc}, QProcess::ReadWrite);
+    gif.start(ffmpeg, {"-i", testFile, gifLoc}, QProcess::ReadWrite);
     gif.waitForFinished();
     qDebug() << gif.readAll();
     bool exportSuccess = gif.exitStatus() == 0 && QFileInfo::exists(gifLoc);
@@ -769,9 +773,10 @@ bool GeneralSettingDialog::ffmpegCheck(const QString& ffmpeg, GeneralSettingDial
     }
     // Palettegen test
     QProcess palettegen;
-    palettegen.start(ffmpeg, {"-i", testFile, "-vf", "palettegen", "palette.png"}, QProcess::ReadWrite);
+    QString palettegenLoc = ffmpegOutputDir.absoluteFilePath("palette.gif");
+    palettegen.start(ffmpeg, {"-i", testFile, "-vf", "palettegen", palettegenLoc}, QProcess::ReadWrite);
     palettegen.waitForFinished();
-    bool pGenSuccess = palettegen.exitStatus() == 0 && QFileInfo::exists("palette.png");
+    bool pGenSuccess = palettegen.exitStatus() == 0 && QFileInfo::exists(palettegenLoc);
     if (!pGenSuccess) {
         ffmpegNotif.setWindowTitle(tr("FFmpeg doesn't generate palettes"));
         ffmpegNotif.setText(tr("FFmpeg was unable to generate palettes, please troubleshoot."));
@@ -782,8 +787,8 @@ bool GeneralSettingDialog::ffmpegCheck(const QString& ffmpeg, GeneralSettingDial
         ffCheck.setValue(true);
         return false;
     }
-    qDebug() << "Palette exists: " << QFileInfo::exists("palette.png")
-             << "| Palette remove: " << QFile("palette.png").remove();
+    qDebug() << "Palette exists: " << QFileInfo::exists(palettegenLoc)
+             << "| Palette remove: " << QFile(palettegenLoc).remove();
     palettegen.deleteLater();
     return true;
 }


### PR DESCRIPTION
On NixOS the ffmpeg check tries to write to a read-only path, so the check always fails even if ffmpeg is available.

This PR changes ffmpegCheck() to use a temporary directory instead.

<hr>

P.S.: `QTemporaryDir` creates a temporary directory and deletes it when the object is destroyed.
- https://doc.qt.io/qt-6/qtemporarydir.html (since Qt 6.4)